### PR TITLE
This commit brings in changes to allow building glb-director, glb-hea…

### DIFF
--- a/src/glb-director/cli/Makefile
+++ b/src/glb-director/cli/Makefile
@@ -73,44 +73,44 @@ LDFLAGS += -ljansson
 
 glb-director-cli: main.c
 	gcc \
-		$(CFLAGS) $(LDFLAGS) \
+		$(CFLAGS) \
 		-I`pwd`/.. \
 		main.c \
-		../siphash24.c \
+		../siphash24.c $(LDFLAGS)\
 		-o glb-director-cli
 
 glb-config-check:
 	gcc \
-		$(CFLAGS) $(LDFLAGS) \
+		$(CFLAGS) \
 		$(CHECK_SRCS) \
 		-o glb-config-check \
 		-I`pwd`/.. \
 		-I/usr/include/dpdk \
 		-I/usr/include/x86_64-linux-gnu \
-		-ldpdk -lpcap \
+		-ldpdk -lpcap $(LDFLAGS)\
 		-m64 -mssse3
 
 glb-director-pcap:
 	gcc \
-		$(CFLAGS) $(LDFLAGS) \
+		$(CFLAGS) \
 		$(PCAP_SRCS) \
 		-o glb-director-pcap \
 		-I`pwd`/.. \
 		-I/usr/include/dpdk \
 		-I/usr/include/x86_64-linux-gnu \
 		-lpcap \
-		-DPCAP_MODE \
+		-DPCAP_MODE $(LDFLAGS)\
 		-m64 -mssse3
 
 glb-director-stub-server:
 	gcc \
-		$(CFLAGS) $(LDFLAGS) \
+		$(CFLAGS) \
 		$(STUB_SRCS) \
 		-o glb-director-stub-server \
 		-I`pwd`/.. \
 		-I/usr/include/dpdk \
 		-I/usr/include/x86_64-linux-gnu \
-		-DPCAP_MODE \
+		-DPCAP_MODE $(LDFLAGS)\
 		-m64 -mssse3
 
 clean:

--- a/src/glb-director/cli/stub_server.c
+++ b/src/glb-director/cli/stub_server.c
@@ -51,6 +51,7 @@
 #include "glb_fwd_config.h"
 #include "shared_opt.h"
 #include "util.h"
+#include "strlcpy.h"
 
 #define DEFAULT_IFACE "lo"
 #define MAX_BUFFER 10240

--- a/src/glb-director/shared_opt.c
+++ b/src/glb-director/shared_opt.c
@@ -64,9 +64,11 @@ void get_options(char *config_file, char *forwarding_table, int argc,
 			/* missing option argument */
 			glb_log_error("%s: option '-%c' requires an argument",
 				      argv[0], optopt);
+			GLB_FALL_THROUGH;
 		case '?':
 			/* invalid option */
 			glb_log_error("Invalid option(s) in command");
+			GLB_FALL_THROUGH;
 		default:
 			abort();
 		}

--- a/src/glb-director/shared_opt.h
+++ b/src/glb-director/shared_opt.h
@@ -43,4 +43,10 @@ extern bool debug;
 void get_options(char *config_file, char *forwarding_table, int argc,
 		 char *const *argv);
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+ #define GLB_FALL_THROUGH __attribute__ ((fallthrough))
+#else
+ #define GLB_FALL_THROUGH ((void)0)
+#endif /* __GNUC__ >= 7 */
+
 #endif

--- a/src/glb-director/siphash24.c
+++ b/src/glb-director/siphash24.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "siphash24.h"
+#include "shared_opt.h"
 
 /* default: SipHash-2-4 */
 #define cROUNDS 2
@@ -114,16 +115,22 @@ int siphash(uint8_t *out, const uint8_t *in, uint64_t inlen, const uint8_t *k)
 	switch (left) {
 	case 7:
 		b |= ((uint64_t)in[6]) << 48;
+		GLB_FALL_THROUGH;
 	case 6:
 		b |= ((uint64_t)in[5]) << 40;
+		GLB_FALL_THROUGH;
 	case 5:
 		b |= ((uint64_t)in[4]) << 32;
+		GLB_FALL_THROUGH;
 	case 4:
 		b |= ((uint64_t)in[3]) << 24;
+		GLB_FALL_THROUGH;
 	case 3:
 		b |= ((uint64_t)in[2]) << 16;
+		GLB_FALL_THROUGH;
 	case 2:
 		b |= ((uint64_t)in[1]) << 8;
+		GLB_FALL_THROUGH;
 	case 1:
 		b |= ((uint64_t)in[0]);
 		break;

--- a/src/glb-director/util.h
+++ b/src/glb-director/util.h
@@ -34,17 +34,16 @@
 #include <rte_branch_prediction.h>
 #include <rte_mbuf.h>
 
-
 #ifdef RTE_EXEC_ENV_BSDAPP
 
 #ifdef __BSD_VISIBLE
 #include "strlcpy.h"
 #endif
-#else
-#ifdef RTE_USE_LIBBSD
-#include "strlcpy.h"
+
 #else
 
+#ifdef RTE_USE_LIBBSD
+#include "strlcpy.h"
 #endif
 
 #endif

--- a/src/glb-director/util.h
+++ b/src/glb-director/util.h
@@ -33,7 +33,22 @@
 
 #include <rte_branch_prediction.h>
 #include <rte_mbuf.h>
+
+
+#ifdef RTE_EXEC_ENV_BSDAPP
+
+#ifdef __BSD_VISIBLE
 #include "strlcpy.h"
+#endif
+#else
+#ifdef RTE_USE_LIBBSD
+#include "strlcpy.h"
+#else
+
+#endif
+
+#endif
+
 
 static inline void burst_free_mbufs(struct rte_mbuf **pkts, unsigned num)
 {

--- a/src/glb-redirect/Makefile
+++ b/src/glb-redirect/Makefile
@@ -40,4 +40,4 @@ mkdeb:
 	sed -i '/^Depends:/ s/$$/, pkg-config, libxtables12 | libxtables10, libxtables-dev | libxtables10/' glb-redirect-iptables-dkms-mkdeb/debian/control
 	sed -i 's/^Maintainer: .*/Maintainer: GitHub <opensource+glb-director@github.com>/' glb-redirect-iptables-dkms-mkdeb/debian/control
 	dkms mkdeb --source-only
-	mv ../glb-redirect-iptables-dkms_$(DKMS_MOD_VER)_all.deb $(BUILDDIR)/
+	mv ../glb-redirect-iptables-dkms_$(DKMS_MOD_VER)_*.deb $(BUILDDIR)/


### PR DESCRIPTION
…lthcheck, glb-redirect as individual components on a Linux device where all the underlying dependencies are present.

Without these changes, the foregoing components could not individually be built (without the use of Docker) due to mismatches between expectations of different respective versions of gcc and linker.