### PR TITLE
Draining multiple nodes together, dumping forwarding-table

### DIFF
--- a/src/glb-director/config_types.h
+++ b/src/glb-director/config_types.h
@@ -1,0 +1,64 @@
+#ifndef __CONFIG_TYPES_H__
+
+#define __CONFIG_TYPES_H__
+
+#define MAX_NUM_BACKENDS 0x100
+
+typedef struct {
+	uint32_t file_fmt_ver;
+	uint32_t num_tables;
+	uint32_t table_entries;
+	uint32_t max_num_backends;
+	uint32_t max_num_binds;
+} bin_file_header;
+
+
+typedef struct {
+	uint32_t inet_family;
+
+	union {
+		char v6[16];
+		struct {
+			uint32_t v4;
+			char reserved[12];
+		};
+	} ip;
+
+	uint16_t state;
+	uint16_t health;
+} backend_entry;
+
+typedef struct {
+	uint32_t inet_family;
+
+	union {
+		char v6[16];
+		struct {
+			uint32_t v4;
+			char _[12];
+		};
+	} ip;
+
+	uint16_t ip_bits;
+
+	uint16_t port_start;
+	uint16_t port_end;
+	uint8_t ipproto;
+	uint8_t reserved;
+} bind_entry;
+
+#if 0
+typedef struct {
+	uint32_t primary_idx;
+	uint32_t secondary_idx;
+} table_entry;
+#endif
+
+struct table_entry_ {
+    uint32_t num_idxs;    
+    uint32_t idxs[MAX_NUM_BACKENDS];
+} __attribute__((__packed__));
+typedef struct table_entry_ table_entry;
+
+
+#endif

--- a/src/glb-director/ftctl/Makefile
+++ b/src/glb-director/ftctl/Makefile
@@ -1,0 +1,20 @@
+all: glb-ftctl
+
+FTCTL_SRCS = main.c
+WERROR_FLAGS += -Werror
+
+#CFLAGS += -O0 -g -Wall $(WERROR_FLAGS)
+CFLAGS += -O0 -g
+
+APP = glb-ftctl
+
+glb-ftctl: $(FTCTL_SRCS)
+	gcc \
+		$(FTCTL_SRCS) \
+		$(CFLAGS) \
+		-I`pwd`/..\
+		-o glb-ftctl
+
+
+clean:
+	rm -Rf glb-ftctl

--- a/src/glb-director/ftctl/main.c
+++ b/src/glb-director/ftctl/main.c
@@ -1,0 +1,190 @@
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "config_types.h"
+
+/*
+ * This file contains code for a utility to dump the contents of a binary
+ * forwarding table (BFT) used by GLB-director.
+ * 
+ * In the future, the displayed items can be displayed in more fancy ways.
+ * This is just a start.
+ */
+
+
+typedef enum {FALSE, TRUE} boolean;
+
+
+/*
+ *
+ */
+void glb_ftctl_usage()
+{
+    printf("Usage: glb-director-ftctl <ft.bin>\n");
+}
+
+/*
+ * fread_ret_check()
+ *
+ * Function to check if the returned count by a call to fread() can be 
+ * considered proper.
+ *
+ */
+
+static int
+glb_fread_ret_check(size_t ret, size_t num_expect_to_read, boolean check_num_expect)
+{
+    /* Improper read */
+    if (check_num_expect) {
+        if (ret < num_expect_to_read) {
+            return 0;
+        }
+    } else {
+        if (!ret) {
+            return 0;
+        }
+    }
+
+    /* Proper read */
+    return 1;
+}
+
+
+int main(int argc, char **argv)
+{
+    char buffer[256];
+    uint32_t i = 0;
+    bin_file_header *bfh;
+    uint32_t num_backends;
+    
+    backend_entry *backendp;
+    bind_entry *bindp;
+    table_entry *tablep;
+
+    //uint32_t num_tables;
+    uint32_t num_binds;
+    char hash_key[16];
+    char ip[INET_ADDRSTRLEN];
+    size_t ret;
+    
+    if (argc != 2) {
+        glb_ftctl_usage();
+        return 1;
+    }
+    
+    const char *src_binary = argv[1];
+
+    /* Open the binary forwarding table file for reading */
+    FILE *in = fopen(src_binary, "rb");
+    if (in == NULL) {
+        printf("Could not open forwarding table file for reading.");
+        return 0;
+    }
+    
+    /* Read magic word */
+    ret = fread(buffer, 4, 1, in);
+    if (!glb_fread_ret_check(ret, 1, TRUE)) {
+        return 0;
+    }
+    
+    /* Read file header */
+    bfh = malloc(sizeof(bin_file_header));
+    if (!bfh) {
+        return 0;
+    }   
+    ret = fread(bfh, sizeof(bin_file_header), 1, in);
+    if (!glb_fread_ret_check(ret, 1, TRUE)) {
+        return 0;
+    }
+
+    
+    /* Read the # of backends that this BFT file knows about */
+    ret = fread(&num_backends, sizeof(uint32_t), 1, in);
+    if (!glb_fread_ret_check(ret, 1, TRUE)) {
+        return 0;
+    }
+    
+    /* Deal with backends : read each backend & display same */
+    backendp = (backend_entry*) malloc(bfh->max_num_backends * \
+                                       sizeof(backend_entry));
+    if (!backendp) {
+        return 0;
+    }   
+    ret = fread(backendp, sizeof(backend_entry), bfh->max_num_backends, in);
+    if (!glb_fread_ret_check(ret, bfh->max_num_backends, FALSE)) {
+        return 0;
+    }
+    
+    for (i = 0; i < num_backends; i++) {
+        printf("\n i = %u, Family = %d, State = %d, Health = %d, IP = %s",
+               i, backendp[i].inet_family, backendp[i].state,
+               backendp[i].health,
+               inet_ntop(AF_INET, (const void *)&backendp[i].ip, ip,
+                         INET_ADDRSTRLEN));
+    }
+
+
+    
+    /* Number of binds */
+    ret = fread(&num_binds, sizeof(uint32_t), 1, in);
+    if (!glb_fread_ret_check(ret, 1, TRUE)) {
+        return 0;
+    }
+
+    
+    /* Deal with binds: read & display each bind entry */
+    bindp = (bind_entry *)malloc(bfh->max_num_binds * sizeof(bind_entry));
+    if (!bindp) {
+        return 0;
+    }
+    
+    ret = fread(bindp, sizeof(bind_entry), bfh->max_num_binds, in);
+    if (!glb_fread_ret_check(ret, bfh->max_num_binds, TRUE)) {
+        return 0;
+    }
+#if 0
+    for (i = 0; i < bfh->max_num_binds; i++) {
+
+    }
+#endif
+    free(bindp);
+
+    
+    /* Hash key */
+    ret = fread(hash_key, 16, 1, in);
+    if (!glb_fread_ret_check(ret, 1, TRUE)) {
+        return 0;
+    }
+    printf("\nHash-key is %s", hash_key);
+    
+    
+    /* Deal with the rendezvous hash-table */
+    tablep = (table_entry *)malloc(bfh->table_entries * sizeof(table_entry));
+    if (!tablep) {
+        return 0;
+    }
+    ret = fread(tablep, sizeof(table_entry), bfh->table_entries, in);
+    if (!glb_fread_ret_check(ret, bfh->table_entries, FALSE)) {
+        return 0;
+    }
+    
+    for (i = 0; i < bfh->table_entries; i++) {
+        int j = 0;
+        int num_idxs;
+
+        num_idxs = tablep->num_idxs;
+        printf("\n");
+        for (j = 0; j < num_idxs; j++) {
+            printf(" \t\t  index= %x %s", tablep[i].idxs[j],
+                   inet_ntop(AF_INET,
+							 (const void *)&backendp[tablep[i].idxs[j]].ip, ip,
+							 INET_ADDRSTRLEN));
+		}
+	}
+	printf("\n");
+	free(tablep);
+	free(backendp);
+	
+	free(bfh);
+
+}

--- a/src/glb-director/glb_encap.c
+++ b/src/glb-director/glb_encap.c
@@ -299,11 +299,7 @@ static int glb_add_packet_route(struct glb_fwd_config_content_table *table, glb_
 	// Match packets onto the via (first hop) and alt (second hop)
 	uint64_t hash_idx = pkt_hash & GLB_FMT_TABLE_HASHMASK;
 	struct glb_fwd_config_content_table_entry *table_entry = &table->entries[hash_idx];
-	uint32_t primary_idx = table_entry->primary;
-	uint32_t secondary_idx = table_entry->secondary;
-	struct glb_fwd_config_content_table_backend *primary = &table->backends[primary_idx];
-	struct glb_fwd_config_content_table_backend *secondary = &table->backends[secondary_idx];
-
+	
 	// include both hops as viable servers, in order.
 	if (unlikely(route_context->hop_count + 2 > MAX_HOPS)) {
 		return -1;
@@ -314,9 +310,14 @@ static int glb_add_packet_route(struct glb_fwd_config_content_table *table, glb_
 		route_context->pkt_hash = pkt_hash;
 	}
 
-	route_context->ipv4_hops[route_context->hop_count] = primary->ipv4_addr;
-	route_context->ipv4_hops[route_context->hop_count + 1] = secondary->ipv4_addr;
-	route_context->hop_count += 2;
+	uint32_t i = 0;
+
+	while (i < table_entry->num_idxs) {
+	    route_context->ipv4_hops[route_context->hop_count] = \
+		  table->backends[i].ipv4_addr;
+	    route_context->hop_count ++;
+		i++;
+	}
 
 	return 0;
 }

--- a/src/glb-director/glb_encap.h
+++ b/src/glb-director/glb_encap.h
@@ -78,7 +78,7 @@ struct l4_ports_hdr {
 	sizeof(uint16_t) \
 )
 
-#define MAX_HOPS 4
+#define MAX_HOPS 255
 
 typedef struct {
 	// aiding simple header extraction by maintaining state

--- a/src/glb-director/glb_fwd_config.h
+++ b/src/glb-director/glb_fwd_config.h
@@ -83,8 +83,8 @@ struct glb_fwd_config_content_table_bind {
 } __attribute__((__packed__));
 
 struct glb_fwd_config_content_table_entry {
-	uint32_t primary;
-	uint32_t secondary;
+    uint32_t num_idxs;
+    uint32_t idxs[GLB_FMT_MAX_NUM_BACKENDS];
 } __attribute__((__packed__));
 
 struct glb_fwd_config_content_table {

--- a/src/glb-director/script/cibuild
+++ b/src/glb-director/script/cibuild
@@ -39,8 +39,11 @@ cd $ROOTDIR
 make clean
 make -C cli clean
 
+make -C ftctl clean
+
 make
 make -C cli
+make -C ftctl
 
 ./cli/glb-director-cli build-config packaging/forwarding_table.json packaging/forwarding_table.bin
 
@@ -55,6 +58,7 @@ fpm -f -s dir -t deb \
 	--config-files /etc \
 	build/app/glb-director=/usr/sbin/ \
 	cli/glb-director-cli=/usr/sbin/ \
+	ftctl/glb-ftctl=/usr/sbin/ \
 	cli/glb-config-check=/usr/sbin/ \
 	packaging/director.conf=/etc/glb/ \
 	packaging/forwarding_table.bin=/etc/glb/ \


### PR DESCRIPTION
1. Changes for inserting >2 nodes per row in the rendezvous-hash table
2. GUE encoding for containing >2 nodes. I've tested upto 5. [Still to test with 255 backends].
3. Forwarding table dump utility: can make this more fancy based on inputs about whichever format we want to display the output in.
4. Some code refactoring to deal with shared data structs.

Sending review in parts for easier parsing: Upon review completion, please
don't merge this yet into master.

Things to do: 
1. Make small code changes for:
      - Reducing forwarding-table-binary (FTB) size
      - FT dump utility: Print the binds, and handle multiple-tables: still being tested.
2. Need to vet some pre-existing unit-tests